### PR TITLE
Switched from direct DeltaTextInputClient calls, to sending JSON through the TextInputClient system channel

### DIFF
--- a/lib/src/input_method_engine.dart
+++ b/lib/src/input_method_engine.dart
@@ -81,7 +81,7 @@ class ImeSimulator {
 
     // Pretend that we're the host platform and send our IME deltas to the app, as
     // if the user typed them.
-    imeClient.updateEditingValueWithDeltas(deltas);
+    await _sendDeltasThroughChannel(deltas);
 
     // Let the app handle the deltas, however long it takes.
     await _tester.pumpAndSettle();
@@ -108,7 +108,7 @@ class ImeSimulator {
     //
     // If the selection is collapsed, we backspace a single character. If the selection is expanded,
     // we delete the selection.
-    imeClient.updateEditingValueWithDeltas([
+    await _sendDeltasThroughChannel([
       TextEditingDeltaDeletion(
         oldText: imeClient.currentTextEditingValue!.text,
         deletedRange: imeClient.currentTextEditingValue!.selection.isCollapsed
@@ -126,5 +126,96 @@ class ImeSimulator {
 
     // Let the app handle the deltas, however long it takes.
     await _tester.pumpAndSettle();
+  }
+
+  Future<void> _sendDeltasThroughChannel(List<TextEditingDelta> deltas) async {
+    // TODO(Flutter): use constants instead of inline strings for message names
+    // TODO(Flutter): provide a fromJSON() for deltas
+    // TODO(Flutter): delta composing region uses `start` and `end` terminology, but the map key is `composingBase` and
+    //                `composingExtent`. These are different concepts.
+    // TODO(Flutter): bad messages or values fail silently. I have to trace through the code to figure out what's wrong
+    //                with my test input.
+    final ByteData? messageBytes = const JSONMessageCodec().encodeMessage(<String, dynamic>{
+      'args': <dynamic>[
+        1,
+        {
+          "deltas": [
+            for (final delta in deltas) //
+              _deltaToJson(delta, delta.oldText),
+          ],
+        },
+      ],
+      'method': 'TextInputClient.updateEditingStateWithDeltas',
+    });
+
+    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+      'flutter/textinput',
+      messageBytes,
+      (ByteData? _) {},
+    );
+  }
+
+  Map<String, dynamic> _deltaToJson(TextEditingDelta delta, String oldText) {
+    if (delta is TextEditingDeltaInsertion) {
+      return {
+        "oldText": oldText,
+        "deltaStart": delta.insertionOffset,
+        "deltaEnd": delta.insertionOffset,
+        "deltaText": delta.textInserted,
+        "selectionBase": delta.selection.baseOffset,
+        "selectionExtent": delta.selection.extentOffset,
+        "selectionAffinity": _fromTextAffinity(delta.selection.affinity),
+        "selectionIsDirection": false,
+        "composingBase": -1,
+        "composingExtent": -1,
+      };
+    } else if (delta is TextEditingDeltaReplacement) {
+      return {
+        "oldText": oldText,
+        "deltaStart": delta.replacedRange.start,
+        "deltaEnd": delta.replacedRange.end,
+        "deltaText": delta.replacementText,
+        "selectionBase": delta.selection.baseOffset,
+        "selectionExtent": delta.selection.extentOffset,
+        "selectionAffinity": _fromTextAffinity(delta.selection.affinity),
+        "selectionIsDirection": false,
+        "composingBase": -1,
+        "composingExtent": -1,
+      };
+    } else if (delta is TextEditingDeltaDeletion) {
+      return {
+        "oldText": oldText,
+        "deltaStart": delta.deletedRange.start,
+        "deltaEnd": delta.deletedRange.end,
+        "deltaText": "",
+        "selectionBase": delta.selection.baseOffset,
+        "selectionExtent": delta.selection.extentOffset,
+        "selectionAffinity": _fromTextAffinity(delta.selection.affinity),
+        "selectionIsDirection": false,
+        "composingBase": -1,
+        "composingExtent": -1,
+      };
+    } else if (delta is TextEditingDeltaNonTextUpdate) {
+      return {
+        "oldText": oldText,
+        "selectionBase": delta.selection.baseOffset,
+        "selectionExtent": delta.selection.extentOffset,
+        "selectionAffinity": _fromTextAffinity(delta.selection.affinity),
+        "selectionIsDirection": delta.selection.isDirectional,
+        "composingBase": delta.composing.start,
+        "composingExtent": delta.composing.end,
+      };
+    }
+
+    throw Exception("Invalid delta: $delta");
+  }
+
+  String _fromTextAffinity(TextAffinity affinity) {
+    switch (affinity) {
+      case TextAffinity.downstream:
+        return 'TextAffinity.downstream';
+      case TextAffinity.upstream:
+        return 'TextAffinity.upstream';
+    }
   }
 }

--- a/lib/src/input_method_engine.dart
+++ b/lib/src/input_method_engine.dart
@@ -129,12 +129,6 @@ class ImeSimulator {
   }
 
   Future<void> _sendDeltasThroughChannel(List<TextEditingDelta> deltas) async {
-    // TODO(Flutter): use constants instead of inline strings for message names
-    // TODO(Flutter): provide a fromJSON() for deltas
-    // TODO(Flutter): delta composing region uses `start` and `end` terminology, but the map key is `composingBase` and
-    //                `composingExtent`. These are different concepts.
-    // TODO(Flutter): bad messages or values fail silently. I have to trace through the code to figure out what's wrong
-    //                with my test input.
     final ByteData? messageBytes = const JSONMessageCodec().encodeMessage(<String, dynamic>{
       'args': <dynamic>[
         1,

--- a/test/basic_ime_client.dart
+++ b/test/basic_ime_client.dart
@@ -37,6 +37,7 @@ class _BareBonesTextFieldWithInputClientState extends State<BareBonesTextFieldWi
 
   @override
   void dispose() {
+    _textInputConnection?.close();
     _focusNode.dispose();
     super.dispose();
   }
@@ -64,7 +65,11 @@ class _BareBonesTextFieldWithInputClientState extends State<BareBonesTextFieldWi
       // ignore: prefer_conditional_assignment
       if (_textInputConnection == null) {
         setState(() {
-          _textInputConnection = TextInput.attach(this, const TextInputConfiguration());
+          _textInputConnection = TextInput.attach(
+              this,
+              const TextInputConfiguration(
+                enableDeltaModel: true,
+              ));
           _textInputConnection!
             ..show()
             ..setEditingState(currentTextEditingValue!);

--- a/test/flutter_test_robots_ime_test.dart
+++ b/test/flutter_test_robots_ime_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/src/input_method_engine.dart';
 
@@ -6,6 +7,14 @@ import 'basic_ime_client.dart';
 
 void main() {
   group("IME simulator", () {
+    tearDown(() {
+      // This line seems to be required when running multiple tests because without
+      // it, the previous `TextInputConnection` ID remains across tests and causes
+      // problems within Flutter. This is true even when explicitly closing the
+      // connection in a widget's `dispose()` method.
+      TextInputConnection.debugResetId();
+    });
+
     testWidgets("types characters", (tester) async {
       await _pumpScaffold(tester);
       await tester.tap(find.byType(BareBonesTextFieldWithInputClient));


### PR DESCRIPTION
Switched from direct DeltaTextInputClient calls, to sending JSON through the TextInputClient system channel.

Here are some relevant Flutter references to understand this approach:

- An internal Flutter test that sends JSON through the text input client channel: https://github.com/Abhisolanki16/talkr_main_updated/blob/1e36480b1a5c178298e1c86753827528454af5fd/packages/flutter/test/services/delta_text_input_test.dart
- Where Flutter handles delta JSON in the channel: https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/services/text_input.dart#L1803
- Where Flutter deserializes the delta JSON: https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/services/text_editing_delta.dart#L65
- 