### PR TITLE
Add a method to send arbitrary deltas through the IME API

### DIFF
--- a/test/basic_ime_client.dart
+++ b/test/basic_ime_client.dart
@@ -17,7 +17,7 @@ class BareBonesTextFieldWithInputClient extends StatefulWidget {
 }
 
 class _BareBonesTextFieldWithInputClientState extends State<BareBonesTextFieldWithInputClient>
-    implements DeltaTextInputClient {
+    with DeltaTextInputClient, TextInputClient {
   late FocusNode _focusNode;
   TextInputConnection? _textInputConnection;
 

--- a/test/flutter_test_robots_ime_test.dart
+++ b/test/flutter_test_robots_ime_test.dart
@@ -76,6 +76,34 @@ void main() {
 
       expect(find.text("A💙"), findsOneWidget);
     });
+
+    testWidgets("dispatches arbitrary deltas", (tester) async {
+      await _pumpScaffold(
+        tester,
+        const TextEditingValue(
+          text: "Abc",
+          selection: TextSelection(baseOffset: 1, extentOffset: 3),
+        ),
+      );
+
+      await tester.tap(find.byType(BareBonesTextFieldWithInputClient));
+
+      // Dispatch a delta to insert the letter 'd' at the end of the text.
+      await tester.ime.sendDeltas(
+        const [
+          TextEditingDeltaInsertion(
+            oldText: "Abc",
+            textInserted: "d",
+            insertionOffset: 3,
+            selection: TextSelection.collapsed(offset: 3),
+            composing: TextSelection.collapsed(offset: 3),
+          )
+        ],
+        finder: find.byType(BareBonesTextFieldWithInputClient),
+      );
+
+      expect(find.text("Abcd"), findsOneWidget);
+    });
   });
 }
 


### PR DESCRIPTION
Add a method to send arbitrary deltas through the IME API

Currently, the `ImeSimulator` API exposes methods to type text and to simulate a backspace, but we can't send arbitrary deltas.

This PR exposes a method to allow sending arbitrary deltas.

This PR also solves a build error in `_BareBonesTextFieldWithInputClientState` caused by new methods that were added to `TextInputClient`.