### PR TITLE
Adds ctrl+home/end, cmd+home/end key combinations

### DIFF
--- a/lib/src/input_method_engine.dart
+++ b/lib/src/input_method_engine.dart
@@ -192,7 +192,7 @@ class ImeSimulator {
       'method': 'TextInputClient.updateEditingStateWithDeltas',
     });
 
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+    await _tester.binding.defaultBinaryMessenger.handlePlatformMessage(
       'flutter/textinput',
       messageBytes,
       (ByteData? _) {},

--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -459,6 +459,38 @@ extension KeyboardInput on WidgetTester {
     await sendKeyEvent(LogicalKeyboardKey.escape, platform: 'macos');
     await pumpAndSettle();
   }
+
+  Future<void> pressCmdHome(WidgetTester tester) async {
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.meta, platform: 'macos');
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.home, platform: 'macos');
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.meta, platform: 'macos');
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.home, platform: 'macos');
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pressCmdEnd(WidgetTester tester) async {
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.meta, platform: 'macos');
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.end, platform: 'macos');
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.meta, platform: 'macos');
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.end, platform: 'macos');
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pressCtrlHome(WidgetTester tester) async {
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.control, platform: 'macos');
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.home, platform: 'macos');
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.control, platform: 'macos');
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.home, platform: 'macos');
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pressCtrlEnd(WidgetTester tester) async {
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.control, platform: 'macos');
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.end, platform: 'macos');
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.control, platform: 'macos');
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.end, platform: 'macos');
+    await tester.pumpAndSettle();
+  }
 }
 
 /// Returns a physical keyboard key combination that expects to create the


### PR DESCRIPTION
This PR adds the following 4 new key combinations to `KeyboardInput` extension, 
`pressCmdHome`, `pressCmdEnd`, `pressCtrlHome`, `pressCtrlEnd`.