### PR TITLE
Create a WidgetTester extension to drag scroll bars (Resolves #22)

### DIFF
--- a/lib/flutter_test_robots.dart
+++ b/lib/flutter_test_robots.dart
@@ -3,3 +3,4 @@ library flutter_test_robots;
 export 'src/clipboard.dart';
 export 'src/input_method_engine.dart';
 export 'src/keyboard.dart';
+export 'src/scrollbar.dart';

--- a/lib/src/scrollbar.dart
+++ b/lib/src/scrollbar.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Simulates the user interacting with a Scrollbar.
+extension ScrollbarInteractions on WidgetTester {
+  /// Press a scrollbar thumb at [thumbLocation] and drag it vertically by [delta] pixels.
+  Future<void> dragScrollbar(Offset thumbLocation, double delta) async {
+    //Hover to make the thumb visible with a duration long enough to run the fade in animation.
+    final testPointer = TestPointer(1, PointerDeviceKind.mouse);
+
+    await sendEventToBinding(testPointer.hover(thumbLocation, timeStamp: const Duration(seconds: 1)));
+    await pumpAndSettle();
+
+    // Press the thumb.
+    await sendEventToBinding(testPointer.down(thumbLocation));
+    await pump(const Duration(milliseconds: 40));
+
+    // Move the thumb down.
+    await sendEventToBinding(testPointer.move(thumbLocation + Offset(0, delta)));
+    await pump();
+
+    // Release the pointer.
+    await sendEventToBinding(testPointer.up());
+    await pump();
+  }
+}


### PR DESCRIPTION
Create a WidgetTester extension to drag scroll bars. Resolves #22 

Dragging a scrollbar requires hovering over the scroll bar, waiting for it to appear, and then dragging and releasing it.

This PR adds a `dragScrollbar` method yo make it easier to interacting with a scrollbar.

We can't use a finder to locate the scrollbar thumb because the scrollbar widget uses a single painter to paint both the scrollbar track and the thumb.

We have a `kTapMinTime` constant in super_editor that we use in the tests. I needed to use the value directly here. 
