### PR TITLE
Remove unnecessary tester parameter

### DIFF
--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -636,36 +636,36 @@ extension KeyboardInput on WidgetTester {
     await tester.pumpAndSettle();
   }
 
-  Future<void> pressCmdZ(WidgetTester tester) async {
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
+  Future<void> pressCmdZ() async {
+    await sendKeyDownEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
+    await sendKeyDownEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
   }
 
-  Future<void> pressCtrlZ(WidgetTester tester) async {
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
+  Future<void> pressCtrlZ() async {
+    await sendKeyDownEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
+    await sendKeyDownEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
   }
 
-  Future<void> pressCmdShiftZ(WidgetTester tester) async {
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift, platform: _keyEventPlatform);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
+  Future<void> pressCmdShiftZ() async {
+    await sendKeyDownEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
+    await sendKeyDownEvent(LogicalKeyboardKey.shift, platform: _keyEventPlatform);
+    await sendKeyDownEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.shift, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
   }
 
-  Future<void> pressCtrlShiftZ(WidgetTester tester) async {
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift, platform: _keyEventPlatform);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
+  Future<void> pressCtrlShiftZ() async {
+    await sendKeyDownEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
+    await sendKeyDownEvent(LogicalKeyboardKey.shift, platform: _keyEventPlatform);
+    await sendKeyDownEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.keyZ, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.shift, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
   }
 }
 

--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -604,36 +604,36 @@ extension KeyboardInput on WidgetTester {
     await pumpAndSettle();
   }
 
-  Future<void> pressCmdHome(WidgetTester tester) async {
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.home, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.home, platform: _keyEventPlatform);
-    await tester.pumpAndSettle();
+  Future<void> pressCmdHome() async {
+    await sendKeyDownEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
+    await sendKeyDownEvent(LogicalKeyboardKey.home, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.home, platform: _keyEventPlatform);
+    await pumpAndSettle();
   }
 
-  Future<void> pressCmdEnd(WidgetTester tester) async {
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.end, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.end, platform: _keyEventPlatform);
-    await tester.pumpAndSettle();
+  Future<void> pressCmdEnd() async {
+    await sendKeyDownEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
+    await sendKeyDownEvent(LogicalKeyboardKey.end, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.meta, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.end, platform: _keyEventPlatform);
+    await pumpAndSettle();
   }
 
-  Future<void> pressCtrlHome(WidgetTester tester) async {
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.home, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.home, platform: _keyEventPlatform);
-    await tester.pumpAndSettle();
+  Future<void> pressCtrlHome() async {
+    await sendKeyDownEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
+    await sendKeyDownEvent(LogicalKeyboardKey.home, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.home, platform: _keyEventPlatform);
+    await pumpAndSettle();
   }
 
-  Future<void> pressCtrlEnd(WidgetTester tester) async {
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.end, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.end, platform: _keyEventPlatform);
-    await tester.pumpAndSettle();
+  Future<void> pressCtrlEnd() async {
+    await sendKeyDownEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
+    await sendKeyDownEvent(LogicalKeyboardKey.end, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.control, platform: _keyEventPlatform);
+    await sendKeyUpEvent(LogicalKeyboardKey.end, platform: _keyEventPlatform);
+    await pumpAndSettle();
   }
 
   Future<void> pressCmdZ() async {


### PR DESCRIPTION
Remove unnecessary tester parameter

The undo/redo shortcut methods are receiving a `WidgetTester` as a parameter, but this isn't needed because they are declared in a `WidgetTester` extension.

This PR removes the `WidgetTester` parameter.